### PR TITLE
Set gunicorn logging to file

### DIFF
--- a/psiturk/experiment_server.py
+++ b/psiturk/experiment_server.py
@@ -63,8 +63,8 @@ class ExperimentServer(Application):
             'workers': workers,
             'loglevels': self.loglevels,
             'loglevel': self.loglevels[config.getint("Server Parameters", "loglevel")],
-            'accesslog': '-',
-            'errorlog': '-',
+            'accesslog': config.get("Server Parameters", "logfile"),
+            'errorlog': config.get("Server Parameters", "logfile"),
             'proc_name': 'psiturk_experiment_server',
             'limit_request_line': '0'
         }


### PR DESCRIPTION
This changes the gunicorn logging so that it logs to the config file specified in `config.txt`.